### PR TITLE
fix: pass optional region_name

### DIFF
--- a/cloudmon/config.py
+++ b/cloudmon/config.py
@@ -115,7 +115,9 @@ class CloudMonConfig:
         for cloud in zone.clouds:
             c_name = cloud.name
             c_ref = cloud.ref
-            cloud_creds = self.model.get_cloud_creds_by_name(c_ref).dict()
+            cloud_creds = self.model.get_cloud_creds_by_name(c_ref).model_dump(
+                exclude_none=True
+            )
             # We do not need name on that level - it is anyway not what we
             # would expect
             cloud_creds.pop("name")

--- a/cloudmon/tests/unit/service/test_sql.py
+++ b/cloudmon/tests/unit/service/test_sql.py
@@ -81,13 +81,19 @@ class TestSql(base.TestCase):
             inventory=mock.ANY,
             extravars=dict(
                 distro_lookup_path=[
-                    ("{{ ansible_facts.distribution }}"
-                     ".{{ ansible_facts.lsb.codename|default() }}"
-                     ".{{ ansible_facts.architecture }}.yaml"),
-                    ("{{ ansible_facts.distribution }}"
-                     ".{{ ansible_facts.lsb.codename|default() }}.yaml"),
-                    ("{{ ansible_facts.distribution }}"
-                     ".{{ ansible_facts.architecture }}.yaml"),
+                    (
+                        "{{ ansible_facts.distribution }}"
+                        ".{{ ansible_facts.lsb.codename|default() }}"
+                        ".{{ ansible_facts.architecture }}.yaml"
+                    ),
+                    (
+                        "{{ ansible_facts.distribution }}"
+                        ".{{ ansible_facts.lsb.codename|default() }}.yaml"
+                    ),
+                    (
+                        "{{ ansible_facts.distribution }}"
+                        ".{{ ansible_facts.architecture }}.yaml"
+                    ),
                     "{{ ansible_facts.distribution }}.yaml",
                     "{{ ansible_facts.os_family }}.yaml",
                     "default.yaml",
@@ -113,8 +119,8 @@ class TestSql(base.TestCase):
             playbook="manage_databases.yaml",
             inventory=mock.ANY,
             extravars=dict(
-                postgres_root_password='abc',
-                postgresql_group_name='postgres',
+                postgres_root_password="abc",
+                postgresql_group_name="postgres",
                 databases=[],
             ),
             verbosity=1,

--- a/cloudmon/tests/unit/test_config.py
+++ b/cloudmon/tests/unit/test_config.py
@@ -39,6 +39,7 @@ class TestConfig(base.TestCase):
           profile: _b
           auth:
             x: _y
+          region_name: _r
       database:
         postgres_postgres_password: abc
         databases:
@@ -73,6 +74,7 @@ class TestConfig(base.TestCase):
           profile: b1
         - name: c2
           profile: b2
+          region_name: r2
       database:
         databases:
           - name: d1
@@ -131,7 +133,11 @@ class TestConfig(base.TestCase):
                 },
                 "x": {
                     "name": "x",
-                    "data": {"profile": "_b", "auth": {"x": "_y"}},
+                    "data": {
+                        "profile": "_b",
+                        "auth": {"x": "_y"},
+                        "region_name": "_r",
+                    },
                 },
             },
         )
@@ -142,7 +148,11 @@ class TestConfig(base.TestCase):
             config.get_env_cloud_credentials("e1", "z1", "x"),
             {
                 "name": "x",
-                "data": {"profile": "_b", "auth": {"x": "_y"}},
+                "data": {
+                    "profile": "_b",
+                    "auth": {"x": "_y"},
+                    "region_name": "_r",
+                },
             },
         )
 
@@ -211,11 +221,13 @@ class TestConfig(base.TestCase):
                             "name": "c1",
                             "profile": "b1",
                             "auth": {"x": "y1"},
+                            "region_name": None,
                         },
                         {
                             "name": "c2",
                             "profile": "b2",
                             "auth": {"x": "y2"},
+                            "region_name": "r2",
                         },
                     ],
                     config.model.clouds_credentials.model_dump(),

--- a/cloudmon/types.py
+++ b/cloudmon/types.py
@@ -28,6 +28,8 @@ class CloudCredentialModel(BaseModel):
     """Optional OpenStack profile to use with credentials"""
     auth: dict
     """Auth block (as in clouds.yaml)"""
+    region_name: str = None
+    """Optional OpenStack profile region name"""
 
 
 class CloudCredentialsModel(RootModel):
@@ -314,9 +316,7 @@ class PluginModel(RootModel):
 
 
 class PluginRefModel(RootModel):
-    root: Union[
-        PluginApimonRefModel, PluginEpmonRefModel, PluginGeneralModel
-    ]
+    root: Union[PluginApimonRefModel, PluginEpmonRefModel, PluginGeneralModel]
 
 
 class StatusDashboardModel(BaseModel):


### PR DESCRIPTION
in the cloud_creds we have region_name and we should add this into the
model so that they end up in XXmon configs.
