### PR TITLE
feat: allow arbitrary attrs in cloud credentials

### DIFF
--- a/cloudmon/tests/unit/test_config.py
+++ b/cloudmon/tests/unit/test_config.py
@@ -40,6 +40,7 @@ class TestConfig(base.TestCase):
           auth:
             x: _y
           region_name: _r
+          foo: bar
       database:
         postgres_postgres_password: abc
         databases:
@@ -137,6 +138,7 @@ class TestConfig(base.TestCase):
                         "profile": "_b",
                         "auth": {"x": "_y"},
                         "region_name": "_r",
+                        "foo": "bar",
                     },
                 },
             },
@@ -152,6 +154,7 @@ class TestConfig(base.TestCase):
                     "profile": "_b",
                     "auth": {"x": "_y"},
                     "region_name": "_r",
+                    "foo": "bar",
                 },
             },
         )
@@ -278,5 +281,5 @@ class TestConfig(base.TestCase):
                             }
                         ],
                     },
-                    config.model.database.dict(),
+                    config.model.database.model_dump(),
                 )

--- a/cloudmon/types.py
+++ b/cloudmon/types.py
@@ -15,12 +15,14 @@ from typing import Literal
 from typing import Union
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import RootModel
 
 
 class CloudCredentialModel(BaseModel):
     """Cloud Credentials"""
+    model_config = ConfigDict(extra='allow')
 
     name: str
     """Credential name (for reference)"""
@@ -36,7 +38,7 @@ class CloudCredentialsModel(RootModel):
     root: List[CloudCredentialModel]
 
     def get_by_name(self, name) -> CloudCredentialModel:
-        for item in self.roo_:
+        for item in self.root:
             if item.name == name:
                 return item
 


### PR DESCRIPTION
It may be desired to set also other data into the cloud_creds. Modify
the model to allow extra attributes and verify this in the test.
