### PR TITLE
[Feat.] Add globalmon plugin to Cloudmon tool

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,3 +54,6 @@ cloudmon.manager =
     epmon_provision = cloudmon.cli.epmon:EpmonProvision
     epmon_start = cloudmon.cli.epmon:EpmonStart
     epmon_stop = cloudmon.cli.epmon:EpmonStop
+    globalmon_provision = cloudmon.cli.globalmon:GlobalmonProvision
+    globalmon_start = cloudmon.cli.globalmon:GlobalmonStart
+    globalmon_stop = cloudmon.cli.globalmon:GlobalmonStop


### PR DESCRIPTION
1. Create cloudmon CLI options for globalmon
2. Define globalmon plugin for cloudmon
3. Create Ansible role/playbooks to install, start and stop globalmon